### PR TITLE
CASMCMS-7619: add jq and yq to make up for lost --export option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget -q https://storage.googleapis.com/kubernetes-release/release/${kubectl_
 # kubectl-docker
 ##########################
 FROM docker:${docker_image_version} as kubectl-docker
-
+RUN apk add --upgrade --no-cache apk-tools &&  apk update && apk add --no-cache jq yq && apk -U upgrade --no-cache
 COPY --from=install /usr/local/bin/kubectl /usr/local/bin/
 COPY ./bin/update-image-registry-secrets.sh /usr/local/bin/update-image-registry-secrets
 RUN chmod +x /usr/local/bin/update-image-registry-secrets


### PR DESCRIPTION
## Summary and Scope

Kubectl deprecrated the --export option for the get subcommand,
so add jq and yq to allow operations to parse out necessary information
like the pre-upgrade hook for the cray-product-catalog chart.

This change is backwards compatible.

## Issues and Related PRs

* Future work required by CASMCMS-7619

## Testing

### Tested on:

  * `Mug`

## Risks and Mitigations

None
